### PR TITLE
add registration button  and remove mailing list subscription

### DIFF
--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -19,6 +19,7 @@
     <p class="hero-presents-text">
       Learn. Build. Share.
     </p>
+    <!-- MAILING LIST SUBSCRIPTION FORM
     <p class="hero-mailing-list-text">
       Join our mailing list for updates about our events!
     </p>
@@ -27,6 +28,7 @@
       <button :class="{active: email}" @click="submit">
         Subscribe
       </button>
+    </div> -->
     </div>
   </div>
 </template>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -35,7 +35,7 @@
       Learn, Build, and Share with us at HackCamp 2020.
     </p>
     <div class="register-btn-container">
-      <button :class="hi" @click="register">
+      <button @click="register">
         REGISTER HERE
       </button>
     </div>
@@ -258,6 +258,7 @@ $body-font: "Source Sans Pro", sans-serif;
     color: white;
     outline: none;
     transition: 0.25s;
+    font-weight: bold;
     &:active {
       background: #ffbc96;
       color: #172b3b;

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -29,6 +29,15 @@
         Subscribe
       </button>
     </div> -->
+    <p class="hero-mailing-list-text">
+      <span class="hero-mailing-list-text bold">
+        Registration is now live!</span><br>
+      Learn, Build, and Share with us at HackCamp 2020.
+    </p>
+    <div class="register-btn-container">
+      <button :class="hi" @click="register">
+        REGISTER HERE
+      </button>
     </div>
   </div>
 </template>
@@ -180,6 +189,10 @@ $body-font: "Source Sans Pro", sans-serif;
   font-size: 16px;
   line-height: 20px;
   padding: 10px 0;
+  span {
+    line-height: 28px;
+    font-weight: bold;
+  }
 }
 
 .hero-lhd-logo {
@@ -223,6 +236,33 @@ $body-font: "Source Sans Pro", sans-serif;
     outline: none;
     transition: 0.25s;
     &.active {
+      background: #ffbc96;
+      color: #172b3b;
+    }
+  }
+}
+
+.register-btn-container {
+  position: relative;
+  z-index: 2;
+  font-size: 16px;
+  line-height: 20px;
+
+  button {
+    cursor: pointer;
+    width: 160px;
+    height: 52px;
+    background: rgba(6, 26, 44, 0.76);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 33px;
+    color: white;
+    outline: none;
+    transition: 0.25s;
+    &:active {
+      background: #ffbc96;
+      color: #172b3b;
+    }
+    &:hover {
       background: #ffbc96;
       color: #172b3b;
     }

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -250,7 +250,6 @@ $body-font: "Source Sans Pro", sans-serif;
 
   button {
     cursor: pointer;
-    width: 160px;
     height: 52px;
     background: rgba(6, 26, 44, 0.76);
     border: 1px solid rgba(0, 0, 0, 0.08);
@@ -259,6 +258,8 @@ $body-font: "Source Sans Pro", sans-serif;
     outline: none;
     transition: 0.25s;
     font-weight: bold;
+    font-size: 18px;
+    padding: 0px 36px;
     &:active {
       background: #ffbc96;
       color: #172b3b;
@@ -296,6 +297,12 @@ $body-font: "Source Sans Pro", sans-serif;
     font-size: 14px;
     line-height: 10px;
     padding: 10px 0;
+  }
+
+  .register-btn-container {
+    button{
+      font-size: 14px;
+    }
   }
 
   .hero-email-subscribe {

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -56,6 +56,12 @@ export default {
     }, 300)
   },
   methods: {
+    register() {
+      window.open(
+        'https://forms.gle/LyR1858VvMfhbVFb7',
+        '_blank'
+      )
+    },
     async submit() {
       try {
         await this.$axios.post(process.env.mailingListUrl, {


### PR DESCRIPTION
:tickets: **Ticket(s)**: n/a

---

## :construction_worker: Changes

new hero section registration button replacing the mailing list subscription (for now)

## :thought_balloon: Notes
https://nwplus2020-2021.slack.com/archives/CV9AP0YP7/p1604795595053100
https://www.figma.com/file/hM48VhCe3p8GNFryQsfCLR/HackCamp-2020-Design-Direction?node-id=875%3A2

## :flashlight: Testing Instructions
Go to site hero section, click the CTA (registration button), verify a new tab opens leading you to the HackCamp registration form. 
